### PR TITLE
Replace use of LWP::UserAgent with HTTP::Tiny

### DIFF
--- a/t/client.t
+++ b/t/client.t
@@ -52,6 +52,6 @@ $args->{uri} = 'fake://metabase.example.com/';
 eval { Metabase::Client::Simple->new($args) };
 like(
     $@,
-    qr/Scheme 'fake' is not supported by your LWP::UserAgent/,
+    qr/Scheme 'fake' is not supported/,
     "Bad scheme causes new() to die"
 );


### PR DESCRIPTION
As described in #2, there are various reasons to use HTTP::Tiny instead of LWP::UserAgent.  This PR implements that request, which will also resolve #7 since HTTP::Tiny::can_ssl provides the reason why SSL isn't supported.
